### PR TITLE
Remove packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,46 +14,45 @@ wget -O bootstrap.sh "https://raw.githubusercontent.com/rtuszik/debian-post-inst
 
 This script automates the installation of essential packages and utilities, enhancing the functionality and security of your Debian system. Below is a list of what the script installs:
 
-- Basic Utilities:
-  - [`wget`](https://www.gnu.org/software/wget/) - A utility for non-interactive download of files from the web.
-  - [`gpg`](https://github.com/gpg/gnupg) - A free implementation of the OpenPGP standard.
-  - [`sudo`](https://www.sudo.ws/) - Allows a permitted user to execute a command as the superuser or another user.
-  - [`openssh-server`](https://www.openssh.com/) - Provides the SSH daemon for secure access to the system remotely.
-  - `ca-certificates`: Common CA certificates.
-  - [`curl`](https://github.com/curl/curl) - A tool to transfer data from or to a server.
-  - `lsb-release`: Provides information about the Linux Standard Base and distribution.
+-   Basic Utilities:
 
-- SSH Configuration:
-  - Configures and enables the SSH service for remote access.
-  - Enables root access via SSH (with caution advised).
+    -   [`wget`](https://www.gnu.org/software/wget/) - A utility for non-interactive download of files from the web.
+    -   [`gpg`](https://github.com/gpg/gnupg) - A free implementation of the OpenPGP standard.
+    -   [`sudo`](https://www.sudo.ws/) - Allows a permitted user to execute a command as the superuser or another user.
+    -   [`openssh-server`](https://www.openssh.com/) - Provides the SSH daemon for secure access to the system remotely.
+    -   `ca-certificates`: Common CA certificates.
+    -   [`curl`](https://github.com/curl/curl) - A tool to transfer data from or to a server.
+    -   `lsb-release`: Provides information about the Linux Standard Base and distribution.
 
-- User Configuration:
-  - Adds the current user to the `sudo` group for administrative privileges.
+-   SSH Configuration:
 
-- Debian Post-Installation Setup:
-  - Modifies `sources.list` for additional repositories.
-  - Adds Debian backports for newer versions of packages.
-  - Configures additional repositories and imports GPG keys for software like `eza`.
+    -   Configures and enables the SSH service.
 
-- Commonly Used Packages:
-  - [`fzf`](https://github.com/junegunn/fzf) - A command-line fuzzy finder.
-  - [`git`](https://github.com/git/git) - Distributed version control system.
-  - [`btop`](https://github.com/aristocratos/btop) - Resource monitor that shows usage and stats for processor, memory, disks, network and processes.
-  - [`lm-sensors`](https://github.com/lm-sensors/lm-sensors) - Utilities to read temperature/voltage/fan sensors.
-  - [`mc` (Midnight Commander)](https://github.com/MidnightCommander/mc) - A powerful file manager.
-  - [`detox`](https://github.com/dharple/detox) - Utility to clean up filenames.
-  - [`ncdu`](https://dev.yorhel.nl/ncdu) - NCurses Disk Usage. (Official site, no GitHub repository.)
-  - `nfs-common` - Support files for NFS clients. (Part of the NFS utilities, official page at [Linux NFS](https://linux-nfs.org/))
-  - [`micro`](https://github.com/zyedidia/micro) - Terminal-based text editor that aims to be easy to use and intuitive, while also taking advantage of the capabilities of modern terminals.
+-   User Configuration:
 
-- Docker Installation (All Docker-related packages are part of the Docker organization on GitHub):
-  - Docker components including `docker-ce`, `docker-ce-cli`, `containerd.io`, `docker-buildx-plugin`, `docker-compose-plugin` can be explored at the [Docker GitHub](https://github.com/docker).
+    -   Adds the current user to the `sudo` group.
 
+-   APT-Repo Setup:
+
+    -   Modifies `sources.list` for additional repositories.
+    -   Adds Debian backports for newer versions of packages.
+    -   Configures additional repositories and imports GPG keys for software like `eza`.
+
+-   Commonly Used Packages:
+
+    -   [`git`](https://github.com/git/git) - Distributed version control system.
+    -   [`btop`](https://github.com/aristocratos/btop) - Resource monitor that shows usage and stats for processor, memory, disks, network and processes.
+    -   [`lm-sensors`](https://github.com/lm-sensors/lm-sensors) - Utilities to read temperature/voltage/fan sensors.
+    -   [`ncdu`](https://dev.yorhel.nl/ncdu) - NCurses Disk Usage. (Official site, no GitHub repository.)
+    -   `nfs-common` - Support files for NFS clients. (Part of the NFS utilities, official page at [Linux NFS](https://linux-nfs.org/))
+
+-   Docker Installation (All Docker-related packages are part of the Docker organization on GitHub):
+    -   Docker components including `docker-ce`, `docker-ce-cli`, `containerd.io`, `docker-buildx-plugin`, `docker-compose-plugin` can be explored at the [Docker GitHub](https://github.com/docker).
 
 ## Security Considerations
 
-- The script enables SSH root access. Use strong passwords or SSH keys and consider restricting access by IP where possible.
-- Review the script and adjust package installations or configurations to suit your security policies and requirements.
+-   The script enables SSH root access. Use strong passwords or SSH keys and consider restricting access by IP where possible.
+-   Review the script and adjust package installations or configurations to suit your security policies and requirements.
 
 ## Customization
 
@@ -62,3 +61,4 @@ You can edit the script to add or remove package installations or modify system 
 ## Disclaimer
 
 This script is provided as-is, without warranty. If you encounter issues or have suggestions, please submit an issue or pull request on GitHub.
+

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,8 +3,6 @@
 #define urls
 DOCKER_GPG_URL="https://download.docker.com/linux/debian/gpg"
 DOCKER_REPO_URL="https://download.docker.com/linux/debian"
-EZA_GPG_URL="https://raw.githubusercontent.com/eza-community/eza/main/deb.asc"
-EZA_REPO_URL="http://deb.gierens.de"
 
 # Welcome message
 printf "==== Initializing Bootstrap ====\n\n"
@@ -46,13 +44,6 @@ chmod a+r /etc/apt/keyrings/docker.asc
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] $DOCKER_REPO_URL $debian_codename stable" | tee /etc/apt/sources.list.d/docker.list
 apt_get_update
 
-# Adding eza's repository correctly
-printf "Adding eza's repository...\n"
-mkdir -p /etc/apt/keyrings
-curl -fsSL $EZA_GPG_URL | gpg --dearmor -o /etc/apt/keyrings/gierens.gpg
-echo "deb [signed-by=/etc/apt/keyrings/gierens.gpg] $EZA_REPO_URL stable main" | sudo tee /etc/apt/sources.list.d/gierens.list
-apt_get_update
-
 # Updating system package database and installing required packages
 printf "Updating system package database and installing required packages...\n"
 # Installing openssh-server and firmware packages for better hardware compatibility
@@ -79,7 +70,7 @@ fi
 
 # Installing commonly used packages
 printf "Installing commonly used packages...\n"
-attempt_install git lm-sensors mc ncdu nfs-common btop neovim
+attempt_install git lm-sensors ncdu nfs-common btop neovim
 printf "Completed: Common packages installation.\n\n"
 
 # Docker installation


### PR DESCRIPTION
## Summary by Sourcery

Remove deprecated package installations and EZA repository support, streamline package lists, and update documentation and script formatting accordingly.

Enhancements:
- Rename README section 'Debian Post-Installation Setup' to 'APT-Repo Setup'
- Clean up README and script indentation and formatting

Documentation:
- Remove fzf, mc, detox, and micro from the 'Commonly Used Packages' list
- Update section headings and package lists in README

Chores:
- Remove EZA_GPG_URL, EZA_REPO_URL, and related repository setup from bootstrap.sh
- Remove mc from the bootstrap.sh installation command